### PR TITLE
Remove the octets numbers from the chunked response for blueprint output

### DIFF
--- a/bin/curl-trace-parser
+++ b/bin/curl-trace-parser
@@ -31,6 +31,11 @@ process.stdin.on('end', function() {
   }
   if(option == 'b' || option == '--blueprint'){
     var rawPair = curl.parse(stdin);
+    var response = rawPair['response'];
+    if (/transfer-encoding:\s*?chunked/gi.test(response)) {
+      var hexPattern = /\r\n[0-9a-f]{1,2}\r\n/gi;
+      rawPair['response'] = response.replace(hexPattern, '\r\n');
+    }
     parsedPair = {
       'request': http.parseRequest(rawPair['request']),
       'response': http.parseResponse(rawPair['response'])


### PR DESCRIPTION
Chunked transfer encoding format includes the number of the octets
of the data in each chunk as a part of the response.

This commit adds detection of the `Transfer-Encoding: chunked`
into the parser to strip the numbers from the output for blueprint
format. The output of raw format kept not modified.

This fix probably also resolves issue apiaryio/curl-trace-parser#6.