### PR TITLE
Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,7 @@
 language: node_js
 node_js:
-  - 6
   - 8
-  - 'stable'
-
+  - 10
 script:
   - npm run lint
   - npm run test
-
-notifications:
-  email:
-    recipients:
-      - adam@apiary.io
-    on_success: change
-    on_failure: always

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Parse curl --trace option output to raw HTTP message",
   "main": "lib/parser.js",
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "scripts": {
     "lint": "eslint src/ test/ bin/",


### PR DESCRIPTION
Node 6 is not supported anymore (end of life April 2019). I suppose this will fix Travis builds under https://github.com/apiaryio/curl-trace-parser/pull/32.